### PR TITLE
Provide a default for bundler_path and rspec_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ https_proxy | nil | use https proxy when installing puppet, ruby, serverspec and
 sudo | nil | use sudo to run commands
 env_vars | {} | environment variable to set for rspec
 bundler_path | '/usr/local/bin' | path for bundler command
-rspec_path | nil | path for rspec command
+rspec_path | '/usr/local/bin' | path for rspec command
 runner_url | https://raw.githubusercontent.com /neillturner/serverspec-runners/ master/ansiblespec_runner.rb | url for custom runner
 require_runner | false | run the custom runner instead of rspec directly
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ http_proxy | nil | use http proxy when installing ruby, serverspec and running s
 https_proxy | nil | use https proxy when installing puppet, ruby, serverspec and running serverspec
 sudo | nil | use sudo to run commands
 env_vars | {} | environment variable to set for rspec
-bundler_path | nil | path for bundler command
+bundler_path | '/usr/local/bin' | path for bundler command
 rspec_path | nil | path for rspec command
 runner_url | https://raw.githubusercontent.com /neillturner/serverspec-runners/ master/ansiblespec_runner.rb | url for custom runner
 require_runner | false | run the custom runner instead of rspec directly

--- a/lib/kitchen/verifier/serverspec.rb
+++ b/lib/kitchen/verifier/serverspec.rb
@@ -42,7 +42,7 @@ module Kitchen
       default_config :remove_default_path, false
       default_config :env_vars, {}
       default_config :bundler_path, '/usr/local/bin'
-      default_config :rspec_path, nil
+      default_config :rspec_path, '/usr/local/bin'
       default_config :require_runner, false
       default_config :runner_url, 'https://raw.githubusercontent.com/neillturner/serverspec-runners/master/ansiblespec_runner.rb'
 

--- a/lib/kitchen/verifier/serverspec.rb
+++ b/lib/kitchen/verifier/serverspec.rb
@@ -41,7 +41,7 @@ module Kitchen
       default_config :extra_flags, nil
       default_config :remove_default_path, false
       default_config :env_vars, {}
-      default_config :bundler_path, nil
+      default_config :bundler_path, '/usr/local/bin'
       default_config :rspec_path, nil
       default_config :require_runner, false
       default_config :runner_url, 'https://raw.githubusercontent.com/neillturner/serverspec-runners/master/ansiblespec_runner.rb'


### PR DESCRIPTION
Provides a default of `/usr/local/bin` for `bundler_path` and `rspec_path`.  I still don't understand how to determine in advance what these should be for a given use-case though.