### PR TITLE
Update workstation -> server example code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,16 @@ require 'net/ssh'
 
 RSpec.configure do |config|
   set :host, ENV['KITCHEN_HOSTNAME']
-  # ssh options at http://net-ssh.github.io/ssh/v1/chapter-2.html
-  # ssh via ssh key
-  set :ssh_options, :user => ENV['KITCHEN_USERNAME'], :port => ENV['KITCHEN_PORT'], :paranoid => false, :verbose => :error, :host_key => 'ssh-rsa', :keys => [ ENV['KITCHEN_SSH_KEY'] ]
+  # ssh options at http://net-ssh.github.io/net-ssh/Net/SSH.html#method-c-start
+  # ssh via ssh key (only)
+  set :ssh_options,
+    :user => ENV['KITCHEN_USERNAME'],
+    :port => ENV['KITCHEN_PORT'],
+    :auth_methods => [ 'publickey' ],
+    :keys => [ ENV['KITCHEN_SSH_KEY'] ],
+    :keys_only => true,
+    :paranoid => false,
+    :verbose => :error
   set :backend, :ssh
   set :request_pty, true
 end


### PR DESCRIPTION
Updated readme to tie-down the ssh connection config to only use the kitchen key/ mechanism for ssh.  Previous config only worked because the default sshd config is quite lax and allows multiple attempts (first with no auth, then going through default keys etc).
Also updated the link to the net-ssh docs (the link was to a very old version, missing the up-to-date config params)