### PR TITLE
Support for default pattern

### DIFF
--- a/lib/kitchen/verifier/serverspec.rb
+++ b/lib/kitchen/verifier/serverspec.rb
@@ -35,6 +35,7 @@ module Kitchen
       default_config :color, true
       default_config :default_path, '/tmp/kitchen'
       default_config :patterns, []
+      default_config :default_pattern, false
       default_config :gemfile, nil
       default_config :custom_install_command, nil
       default_config :additional_install_command, nil
@@ -253,6 +254,10 @@ module Kitchen
 
       def rspec_commands
         info('Running Serverspec')
+        if config[:default_pattern]
+          info("Using default pattern #{config[:test_base_path]}/#{config[:suite_name]}/serverspec/*_spec.rb")
+          config[:patterns].push("#{config[:test_base_path]}/#{config[:suite_name]}/serverspec/*_spec.rb")
+        end
         if config[:require_runner]
           "#{env_vars} #{sudo_env(rspec_cmd)} #{color} -f #{config[:format]} --default-path  #{config[:default_path]} #{rspec_path_option} #{config[:extra_flags]}"
         elsif config[:remote_exec]

--- a/lib/kitchen/verifier/serverspec.rb
+++ b/lib/kitchen/verifier/serverspec.rb
@@ -256,7 +256,7 @@ module Kitchen
         info('Running Serverspec')
         if config[:default_pattern]
           info("Using default pattern #{config[:test_base_path]}/#{config[:suite_name]}/serverspec/*_spec.rb")
-          config[:patterns].push("#{config[:test_base_path]}/#{config[:suite_name]}/serverspec/*_spec.rb")
+          config[:patterns] = ["#{config[:test_base_path]}/#{config[:suite_name]}/serverspec/*_spec.rb"]
         end
         if config[:require_runner]
           "#{env_vars} #{sudo_env(rspec_cmd)} #{color} -f #{config[:format]} --default-path  #{config[:default_path]} #{rspec_path_option} #{config[:extra_flags]}"


### PR DESCRIPTION
Hi Neil,

Thank you for kitchen-verifier-serverspec. This PR add support to use default dir behaviour of busser. So it will add a default pattern
i.e. test/integration/SUIT_NAME/serverspec/*_spec.rb
to enable the feature
```yaml
  default_pattern         : true
```
