### PR TITLE
strip the command before passing it to mixlib

### DIFF
--- a/lib/kitchen/verifier/serverspec.rb
+++ b/lib/kitchen/verifier/serverspec.rb
@@ -349,6 +349,7 @@ module Kitchen
       end
 
       def shellout(command)
+        command = command.strip
         info("Running command: #{command}")
         cmd = Mixlib::ShellOut.new(command, config[:shellout_opts])
         cmd.live_stream = config[:live_stream]


### PR DESCRIPTION
unstripped command in windows will throw an invalid parameter error like:
Failed to complete #verify action: [The parameter is incorrect. - CreateProcessW] on default