### PR TITLE
bash: line 6: [: too many arguments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rubocop', '~> 0.34'
 gem 'rake', '~> 10.4.2'
 gem 'rspec', '~> 3.3.0'
+gem 'rubocop', '~> 0.34'
 gem 'simplecov', '~> 0.10'

--- a/lib/kitchen/verifier/serverspec.rb
+++ b/lib/kitchen/verifier/serverspec.rb
@@ -134,7 +134,7 @@ module Kitchen
               if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ]; then
                 #{sudo_env('yum')} -y install ruby
               else
-                if [ -f /etc/system-release ] || [ grep -q 'Amazon Linux' /etc/system-release ]; then
+                if [ -f /etc/system-release ] && grep -q 'Amazon Linux' /etc/system-release; then
                   #{sudo_env('yum')} -y install ruby
                 else
                   #{sudo_env('apt-get')} -y install ruby


### PR DESCRIPTION
This is easily reproducible on a computer with no /etc/system-release

Run this command line in bash:

```
[ -f /etc/system-release ] || [ grep -q 'Amazon Linux' /etc/system-release ]
```

and you get:

`-bash: [: too many arguments`

Run this command line in bash:

```
[ -f /etc/system-release ] && grep -q 'Amazon Linux' /etc/system-release
```

and it runs without an error