### PR TITLE
Check for bundler using standard POSIX command

### DIFF
--- a/lib/kitchen/verifier/serverspec.rb
+++ b/lib/kitchen/verifier/serverspec.rb
@@ -322,7 +322,7 @@ module Kitchen
       end
 
       def bundler_cmd
-        config[:bundler_path] ? "#{config[:bundler_path]}/bundle" : '`which bundle`'
+        config[:bundler_path] ? "#{config[:bundler_path]}/bundle" : '`command -v bundle`'
       end
 
       def bundler_local_cmd

--- a/lib/kitchen/verifier/serverspec.rb
+++ b/lib/kitchen/verifier/serverspec.rb
@@ -322,7 +322,7 @@ module Kitchen
       end
 
       def bundler_cmd
-        config[:bundler_path] ? "#{config[:bundler_path]}/bundle" : '$(which bundle)'
+        config[:bundler_path] ? "#{config[:bundler_path]}/bundle" : '`which bundle`'
       end
 
       def bundler_local_cmd

--- a/lib/kitchen/verifier/serverspec.rb
+++ b/lib/kitchen/verifier/serverspec.rb
@@ -322,7 +322,7 @@ module Kitchen
       end
 
       def bundler_cmd
-        config[:bundler_path] ? "#{config[:bundler_path]}/bundle" : '`command -v bundle`'
+        config[:bundler_path] ? "#{config[:bundler_path]}/bundle" : 'bundle'
       end
 
       def bundler_local_cmd

--- a/lib/kitchen/verifier/serverspec.rb
+++ b/lib/kitchen/verifier/serverspec.rb
@@ -167,7 +167,7 @@ module Kitchen
       def install_bundler
         if config[:remote_exec]
           <<-INSTALL
-            if [ $(#{sudo('gem')} list bundler -i) == 'false' ]; then
+            if ! command -v bundle; then
               #{sudo_env('gem')} install #{gem_proxy_parm} --no-ri --no-rdoc bundler
             fi
           INSTALL


### PR DESCRIPTION
Avoids situation where sudo('gem') is not able to find gem binary:

```
sudo: gem: command not found
bash: line 13: [: ==: unary operator expected
sudo: gem: command not found
bash: line 18: [: ==: unary operator expected
```