### PR TITLE
Amazon Linux 2 Support

### DIFF
--- a/lib/kitchen/verifier/serverspec.rb
+++ b/lib/kitchen/verifier/serverspec.rb
@@ -170,7 +170,7 @@ module Kitchen
       def install_bundler
         if config[:remote_exec]
           <<-INSTALL
-            if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ]; then
+            if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || ( [ -f /etc/os-release ] && grep -q 'Amazon Linux 2' /etc/os-release ); then
               echo '-----> Installing os provided bundler package'
               #{sudo_env('yum')} -y install rubygem-bundler
             else


### PR DESCRIPTION
Thank you for kitchen-verifier-serverspec! It has been really helpful for me on several projects.

Amazon Linux 2 Support:
Install the OS-provided bundler version (similar to how it would be installed for CentOS 7/ RHEL 7, etc)

